### PR TITLE
support < 1GB RAM in clones

### DIFF
--- a/ezmomi/ezmomi.py
+++ b/ezmomi/ezmomi.py
@@ -131,11 +131,12 @@ class EZMomi(object):
 
     def clone(self):
         self.config['hostname'] = self.config['hostname'].lower()
-        self.config['mem'] = self.config['mem'] * 1024  # convert GB to MB
+        self.config['mem'] = int(self.config['mem'] * 1024)  # convert GB to MB
 
-        print "Cloning %s to new host %s..." % (
+        print "Cloning %s to new host %s with %sMB RAM..." % (
             self.config['template'],
-            self.config['hostname']
+            self.config['hostname'],
+            self.config['mem']
         )
 
         # initialize a list to hold our network settings

--- a/ezmomi/params.py
+++ b/ezmomi/params.py
@@ -66,7 +66,7 @@ def add_params(subparsers):
     )
     clone_parser.add_argument(
         '--mem',
-        type=int,
+        type=float,
         help='Memory in GB'
     )
     clone_parser.add_argument(


### PR DESCRIPTION
support < 1GB RAM in clones by changing the config/parser field to a float
- fractional GB memory allowed, example: "mem: 0.25" results in 256MB
- print amount of RAM in the "Cloning ... " message