### PR TITLE
update pyvmomi version from generic 6.7.0 to 6.7.0.2018.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 netaddr==0.7.19
-pyvmomi==6.7.0
+pyvmomi==6.7.0.2018.9
 PyYAML==3.13
 requests==2.19.1
 six==1.11.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=open('README.txt').read(),
     install_requires=[
         "netaddr==0.7.19",
-        "pyvmomi==6.7.0",
+        "pyvmomi==6.7.0.2018.9",
         "PyYAML==3.13",
         "requests==2.19.1",
         "six==1.11.0",


### PR DESCRIPTION
It looks like you can no longer install pyvomi 6.7.0, and need to refine it to a specific build